### PR TITLE
Remove special number behavior

### DIFF
--- a/stenotype_vim.py
+++ b/stenotype_vim.py
@@ -11,6 +11,12 @@ KEYS = (
 
 IMPLICIT_HYPHEN_KEYS = ('A-', 'O-', '-E', '-U', '@', '*')
 
+NUMBER_KEY = None
+
+NUMBERS = {}
+
+FERAL_NUMBER_KEY = False
+
 KEYMAPS = {
     'Gemini PR': {  # for multisteno
         '#'         : ('#1', '#2', '#3', '#4', '#5', '#6', '#7', '#8', '#9', '#A', 'S1-'),


### PR DESCRIPTION
Change the behaviour of the `#` key so that it behaves like any other regular key.

This change will consider `3W0B` as invalid steno only accept `#PWOB`.